### PR TITLE
Update spock dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
   testCompile localGroovy()
   testCompile 'junit:junit:4.11'
   testCompile 'org.hamcrest:hamcrest-all:1.3'
-  testCompile('org.spockframework:spock-core:1.0-groovy-2.3') {
+  testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
     exclude group: 'org.codehaus.groovy'
   }
 }


### PR DESCRIPTION
Otherwise I get the error: "exception org.spockframework.util.IncompatibleGroovyVersionException: The Spock compiler plugin cannot execute because Spock 1.0.0-groovy-2.3 is not compatible with Groovy 2.4.4"